### PR TITLE
Add mfc decorator.

### DIFF
--- a/localscope/__init__.py
+++ b/localscope/__init__.py
@@ -26,11 +26,10 @@ def localscope(func=None, *, predicate=None, allowed=None, allow_closure=False, 
         Globals associated with the root callable which are passed to dependent code blocks for
         analysis.
 
-    Notes
-    -----
-    The localscope decorator analysis the decorated function (and any dependent code blocks) at the
-    time of declaration because static analysis has a minimal impact on performance and  it is
-    easier to implement.
+    Attributes
+    ----------
+    mfc : localscope
+        Decorator allowing *m*\\ odules, *f*\\ unctions, and *c*\\ lasses to enter the local scope.
 
     Examples
     --------
@@ -63,6 +62,23 @@ def localscope(func=None, *, predicate=None, allowed=None, allow_closure=False, 
     ...     print(a)
     >>> print_a()
     hello world
+
+    Localscope is strict by default, but :code:`localscope.mfc` can be used to allow modules,
+    functions, and classes to enter the function scope: a common use case in notebooks.
+
+    >>> class MyClass:
+    ...     pass
+    >>> @localscope.mfc
+    ... def create_instance():
+    ...     return MyClass()
+    >>> create_instance()
+    <MyClass object at 0x...>
+
+    Notes
+    -----
+    The localscope decorator analysis the decorated function (and any dependent code blocks) at the
+    time of declaration because static analysis has a minimal impact on performance and  it is
+    easier to implement.
     """
     # Set defaults
     predicate = predicate or inspect.ismodule
@@ -108,3 +124,10 @@ def localscope(func=None, *, predicate=None, allowed=None, allow_closure=False, 
             localscope(const, _globals=_globals, allow_closure=True, **kwargs)
 
     return func
+
+
+def _allow_mfc(x):
+    return inspect.ismodule(x) or inspect.isfunction(x) or inspect.isclass(x)
+
+
+localscope.mfc = localscope(predicate=_allow_mfc)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 with open('README.rst') as fp:
     long_description = fp.read()
-long_description = long_description.replace('.. doctest::', '.. code-block::')
+long_description = long_description.replace('.. doctest::', '.. code-block:: python')
 long_description = re.sub(r'(\.\. autofunction:: .*?$)', r':code:`\1`', long_description)
 
 
@@ -16,7 +16,7 @@ tests_require = [
 
 setup(
     name='localscope',
-    version='0.1.1',
+    version='0.1.2',
     author='Till Hoffmann',
     packages=find_packages(),
     url='https://github.com/tillahoffmann/localscope',

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -102,3 +102,26 @@ def test_recursive_local_closure():
 
         def child():
             return a
+
+
+def test_mfc():
+    import sys
+
+    x = lambda: 0  # noqa: E731
+
+    class MyClass:
+        pass
+
+    # Check we can access modules, functions, and classes
+    @localscope.mfc
+    def doit():
+        sys.version
+        x()
+        MyClass()
+
+    x = 1
+
+    with pytest.raises(ValueError):
+        @localscope.mfc
+        def breakit():
+            x + 1


### PR DESCRIPTION
Localscope is strict by default, but the `localscope.mfc` decorator can be used to allow modules, functions, and classes to enter the function scope: a common use case in notebooks.