### PR TITLE
Update line number handling and provide better traceback.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "localscope"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.8"
 authors = [
     {name = "Till Hoffmann"},

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [flake8]
 max-line-length = 88
+ignore = E203
 exclude =
+    playground
     venv
 
 [tool:pytest]

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -224,3 +224,27 @@ def test_method():
         @localscope(allowed=["x"])
         def my_func(self, a):
             return a + x
+
+
+def test_source():
+    x = 1
+
+    def foo():
+        # This
+        # is
+        # a
+        # long
+        # source
+        # file.
+        if True:
+            print(x)
+
+        # We
+        # have
+        # printed
+        # something
+        # here.
+
+    with pytest.raises(LocalscopeException) as raised:
+        localscope(foo)
+    assert "--> 240:         print(x)" in str(raised.value)


### PR DESCRIPTION
```python
from localscope import localscope


@localscope
def foo():
    # This
    # is
    # a
    # long
    # source
    # file.
    if True:
        print(x)

    # We
    # have
    # printed
    # something
    # here.
```

```
---------------------------------------------------------------------------
LocalscopeException                       Traceback (most recent call last)
Cell In[4], line 5
      1 from localscope import localscope
      4 @localscope
----> 5 def foo():
      6     # This
      7     # is
      8     # a
      9     # long
     10     # source
     11     # file.
     12     if True:
     13         print(x)

File ~/git/localscope/localscope/__init__.py:103, in localscope(func, predicate, allowed, allow_closure)
     95 if not func:
     96     return ft.partial(
     97         localscope,
     98         allow_closure=allow_closure,
     99         allowed=allowed,
    100         predicate=predicate,
    101     )
--> 103 return _localscope(
    104     func,
    105     allow_closure=allow_closure,
    106     allowed=allowed,
    107     predicate=predicate,
    108     _globals={},
    109 )

File ~/git/localscope/localscope/__init__.py:200, in _localscope(func, predicate, allowed, allow_closure, _globals)
    198 # Complain if the variable is not available.
    199 if name not in _globals:
--> 200     raise LocalscopeException(
    201         f"`{name}` is not in globals", code, instruction, lineno
    202     )
    203 # Check if variable is allowed by value.
    204 value = _globals[name]

LocalscopeException: `x` is not in globals (file "/var/folders/l5/cw82lksx6sd80pskw1npx_kh0000gn/T/ipykernel_50104/3725129688.py", line 13, in foo)
     11:     # file.
     12:     if True:
-->  13:         print(x)
     14: 
     15:     # We
```