### PR TITLE
Correctly handle varargs and keyword-only arguments.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "localscope"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.8"
 authors = [
     {name = "Till Hoffmann"},
@@ -16,3 +16,6 @@ readme = {text = "Restrict the scope of functions for reproducible code executio
 Documentation = "https://localscope.readthedocs.io"
 Repository = "https://github.com/tillahoffmann/localscope.git"
 Issues = "https://github.com/tillahoffmann/localscope/issues"
+
+[tool.setuptools.packages]
+find = {}

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -248,3 +248,11 @@ def test_source():
     with pytest.raises(LocalscopeException) as raised:
         localscope(foo)
     assert "--> 240:         print(x)" in str(raised.value)
+
+
+def test_comprehension_closure():
+    def foo(*a, b):
+        print(a, b)
+        return [(a, b) for _ in ()]
+
+    localscope(foo)


### PR DESCRIPTION
Before this change, the newly added test case would fail.