### PR TITLE
Support calls to `super` in methods.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "localscope"
-version = "0.2.4"
+version = "0.2.5"
 requires-python = ">=3.8"
 authors = [
     {name = "Till Hoffmann"},

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -256,3 +256,23 @@ def test_comprehension_closure():
         return [(a, b) for _ in ()]
 
     localscope(foo)
+
+
+def test_super():
+    class Foo:
+        @localscope
+        def foo(self):
+            return None
+
+    class Bar(Foo):
+        @localscope
+        def foo(cls):
+            return super().foo()
+
+    a = 3
+    with pytest.raises(LocalscopeException):
+
+        class Baz(Foo):
+            @localscope
+            def foo(cls):
+                return super().foo() + a


### PR DESCRIPTION
`inspect.getclosurevars` fails with `Cell is empty` when called on a method that calls `super` during declaration. The call to `super` implicitly relies on the closure of `__class__` which is not available at the time of declaration. This PR adds a modified version of `inspect.getclosurevars` which silently ignores empty cells if the name is `__class__`.