### PR TITLE
Support references outside local scope for variables not yet declared.

### DIFF
--- a/localscope/__init__.py
+++ b/localscope/__init__.py
@@ -308,7 +308,7 @@ def _safely_get_closure_vars(func):  # pragma: no cover
                     nonlocal_vars[var] = EmptyCell
                 else:
                     raise LocalscopeException(
-                        f"Cell for `{var}` is empty: {ex}."
+                        f"Failed to retrieve `{var}` from closure."
                     ) from ex
 
     # Global and builtin references are named in co_names and resolved

--- a/localscope/__init__.py
+++ b/localscope/__init__.py
@@ -297,7 +297,9 @@ def _safely_get_closure_vars(func):  # pragma: no cover
                 nonlocal_vars[var] = cell.cell_contents
             except ValueError as ex:
                 if not (var == "__class__" and str(ex) == "Cell is empty"):
-                    raise ValueError(f"Error when accessing cell contents for `{var}`: {ex}")
+                    raise ValueError(
+                        f"Error when accessing cell contents for `{var}`: {ex}."
+                    )
 
     # Global and builtin references are named in co_names and resolved
     # by looking them up in __globals__ or __builtins__

--- a/localscope/__init__.py
+++ b/localscope/__init__.py
@@ -297,7 +297,7 @@ def _safely_get_closure_vars(func):  # pragma: no cover
                 nonlocal_vars[var] = cell.cell_contents
             except ValueError as ex:
                 if not (var == "__class__" and str(ex) == "Cell is empty"):
-                    raise
+                    raise ValueError(f"Error when accessing cell contents for `{var}`: {ex}")
 
     # Global and builtin references are named in co_names and resolved
     # by looking them up in __globals__ or __builtins__

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -276,3 +276,23 @@ def test_super():
             @localscope
             def foo(cls):
                 return super().foo() + a
+
+def test_obj_defined_later():
+    class Foo:
+        pass
+
+    @localscope(allowed=['our_foo'])
+    def set_foo():
+        our_foo.a = 3
+
+    our_foo = Foo()
+    set_foo()
+    assert our_foo.a == 3
+
+
+
+
+
+
+
+

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -278,14 +278,18 @@ def test_super():
                 return super().foo() + a
 
 
-def test_obj_defined_later():
+def test_use_global_before_defined():
     class Foo:
         pass
 
-    @localscope(allowed=["our_foo"])
-    def set_foo():
-        our_foo.a = 3
+    @localscope(allowed=["foo"])
+    def access_foo_allowed():
+        return foo
 
-    our_foo = Foo()
-    set_foo()
-    assert our_foo.a == 3
+    with pytest.raises(LocalscopeException, match="`foo` is not a permitted global"):
+
+        @localscope
+        def access_foo_not_allowed():
+            return foo
+
+    foo = Foo()

--- a/tests/test_localscope.py
+++ b/tests/test_localscope.py
@@ -277,22 +277,15 @@ def test_super():
             def foo(cls):
                 return super().foo() + a
 
+
 def test_obj_defined_later():
     class Foo:
         pass
 
-    @localscope(allowed=['our_foo'])
+    @localscope(allowed=["our_foo"])
     def set_foo():
         our_foo.a = 3
 
     our_foo = Foo()
     set_foo()
     assert our_foo.a == 3
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Thanks for developing localscope,
it's going to be a great addition to my [Pypipegraph2](https://tyberiusprime.github.io/pypipegraph2/).

One issue I've run into is the test case attached:
I have places where I need to define a function first, and then the object it accesses. That's perfectly valid, if somewhat unusual python. 
Note that this isn't a 'future global', but a 'future captured variable from the outer scope'.

Now this PR only introduces the test case (and polishes the error message a bit), because I see two ways forward:
- either accept empty cells 
- or do not attempt to access cells where var is in allowed.

I'm not sure about the implications of the first, and the user has to add the variable to allowed anyway.

(I guess we could also accept empty cells for entries in allowed... seems convoluted though).

Let me know what you think and I'll write it up either way.

Thanks!