### PR TITLE
auto-add `__version__` to localscope on github build/release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
         cache: pip
     - name: Install dependencies
       run: pip install -r requirements.txt
+    - name: add __version__ to __init__.py
+      run: make version
     - name: Lint code
       run: make lint
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Build documentation, lint the code, and run tests.
 build : doctests docs lint tests dist
 
-dist : pyproject.toml
+dist : pyproject.toml version
 	python -m build
 	twine check dist/*.tar.gz dist/*.whl
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ tests :
 requirements.txt : requirements.in pyproject.toml
 	pip-compile -v $<
 
+version :
+	./dev/add_version_to_init.py
+
 # Docker versions.
 VERSIONS = 3.9 3.10 3.11 3.12 3.13
 IMAGES = $(addprefix docker-image/,${VERSIONS})

--- a/dev/add_version_to_init.py
+++ b/dev/add_version_to_init.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import tomllib
+import re
+
+version = tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]
+input = open("localscope/__init__.py").read()
+output = re.sub(r"__version__ = .*\n", f"__version__ = '{version}'\n", input)
+open("localscope/__init__.py", "w").write(output)

--- a/localscope/__init__.py
+++ b/localscope/__init__.py
@@ -9,6 +9,8 @@ import types
 from typing import Any, Callable, Dict, Iterable, Optional, Set, Union
 
 
+__version__ = 'dev'
+
 LOGGER = logging.getLogger(__name__)
 PY_LT_3_13 = sys.version_info < (3, 13)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "localscope"
-version = "0.2.5"
+version = "0.2.6"
 requires-python = ">=3.9"
 authors = [
     {name = "Till Hoffmann"},


### PR DESCRIPTION
We want the `__version__` to be in sync between pyproject.toml and the one exported by `__init__.py`, at least for pypi releases. This commit adds a script that patches `__init__.py` accordingly in the github workflow, or on 'make version'.

See #20.

I've bumped the version and am pushing from main to test whether a contributor can trigger the release clause in the github actions workflow.