### PR TITLE
Report all non-local variables at once

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -19,5 +19,6 @@ intersphinx_mapping = {
 nitpick_ignore = [
     ("py:class", "code"),
     ("py:class", "function"),
+    ("py:class", "types.LambdaType"),
 ]
 html_theme = "furo"


### PR DESCRIPTION
Current UX is to send devs into a 'run, read error, fix error, run, read next error' loop.

That's not big deal when interactively working with jupyter,
it's a pain if you're retroactively fixing non-local variable access in a larger code base.

This patch allows localscope to report all offending variables at once,
and exposes the list of offending variables as an attribute on the exception.

This way I can have *my* error message contain a copy-pastable `pass in allow_non_locals = ['a','b','c']` instead of a generic `pass in allow_globals = [...]`
string.